### PR TITLE
Option to skip HTML entity decoding.

### DIFF
--- a/HtmlPerformanceKit.Test/DataTest.cs
+++ b/HtmlPerformanceKit.Test/DataTest.cs
@@ -46,6 +46,24 @@ namespace HtmlPerformanceKit.Test
         }
 
         [TestMethod]
+        public void DataDecimalCharacterReferenceWhenDecodingSkipped()
+        {
+            var options = new HtmlReaderOptions
+            {
+                SkipCharacterReferenceDecoding = true
+            };
+
+            reader = HtmlReaderFactory.FromString("&#65;", parseErrors, options);
+
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual(HtmlTokenKind.Text, reader.TokenKind);
+            Assert.AreEqual("&#65;", reader.Text);
+
+            Assert.IsFalse(reader.Read());
+            Assert.AreEqual(0, parseErrors.Count);
+        }
+
+        [TestMethod]
         public void DataHexCharacterReference()
         {
             reader = HtmlReaderFactory.FromString("&#x41;", parseErrors);
@@ -59,6 +77,24 @@ namespace HtmlPerformanceKit.Test
         }
 
         [TestMethod]
+        public void DataHexCharacterReferenceWhenDecodingSkipped()
+        {
+            var options = new HtmlReaderOptions
+            {
+                SkipCharacterReferenceDecoding = true
+            };
+
+            reader = HtmlReaderFactory.FromString("&#x41;", parseErrors, options);
+
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual(HtmlTokenKind.Text, reader.TokenKind);
+            Assert.AreEqual("&#x41;", reader.Text);
+
+            Assert.IsFalse(reader.Read());
+            Assert.AreEqual(0, parseErrors.Count);
+        }
+
+        [TestMethod]
         public void DataNamedCharacterReference()
         {
             reader = HtmlReaderFactory.FromString("&lt;", parseErrors);
@@ -66,6 +102,24 @@ namespace HtmlPerformanceKit.Test
             Assert.IsTrue(reader.Read());
             Assert.AreEqual(HtmlTokenKind.Text, reader.TokenKind);
             Assert.AreEqual("<", reader.Text);
+
+            Assert.IsFalse(reader.Read());
+            Assert.AreEqual(0, parseErrors.Count);
+        }
+
+        [TestMethod]
+        public void DataNamedCharacterReferenceWhenDecodingSkipped()
+        {
+            var options = new HtmlReaderOptions
+            {
+                SkipCharacterReferenceDecoding = true
+            };
+
+            reader = HtmlReaderFactory.FromString("&lt;", parseErrors, options);
+
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual(HtmlTokenKind.Text, reader.TokenKind);
+            Assert.AreEqual("&lt;", reader.Text);
 
             Assert.IsFalse(reader.Read());
             Assert.AreEqual(0, parseErrors.Count);
@@ -87,6 +141,24 @@ namespace HtmlPerformanceKit.Test
         }
 
         [TestMethod]
+        public void DataNamedCharacterReference2WhenDecodingSkipped()
+        {
+            var options = new HtmlReaderOptions
+            {
+                SkipCharacterReferenceDecoding = true
+            };
+
+            reader = HtmlReaderFactory.FromString("I'm &notit; I tell you", parseErrors, options);
+
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual(HtmlTokenKind.Text, reader.TokenKind);
+            Assert.AreEqual("I'm &notit; I tell you", reader.Text);
+
+            Assert.IsFalse(reader.Read());
+            Assert.AreEqual(0, parseErrors.Count);
+        }
+
+        [TestMethod]
         public void DataNamedCharacterReference3()
         {
             reader = HtmlReaderFactory.FromString("I'm &notin; I tell you", parseErrors);
@@ -94,6 +166,24 @@ namespace HtmlPerformanceKit.Test
             Assert.IsTrue(reader.Read());
             Assert.AreEqual(HtmlTokenKind.Text, reader.TokenKind);
             Assert.AreEqual("I'm ∉ I tell you", reader.Text);
+
+            Assert.IsFalse(reader.Read());
+            Assert.AreEqual(0, parseErrors.Count);
+        }
+
+        [TestMethod]
+        public void DataNamedCharacterReference3WhenDecodingSkipped()
+        {
+            var options = new HtmlReaderOptions
+            {
+                SkipCharacterReferenceDecoding = true
+            };
+
+            reader = HtmlReaderFactory.FromString("I'm &notin; I tell you", parseErrors, options);
+
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual(HtmlTokenKind.Text, reader.TokenKind);
+            Assert.AreEqual("I'm &notin; I tell you", reader.Text);
 
             Assert.IsFalse(reader.Read());
             Assert.AreEqual(0, parseErrors.Count);

--- a/HtmlPerformanceKit.Test/HtmlReaderFactory.cs
+++ b/HtmlPerformanceKit.Test/HtmlReaderFactory.cs
@@ -6,17 +6,17 @@ namespace HtmlPerformanceKit.Test
 {
     internal class HtmlReaderFactory
     {
-        public static HtmlReader FromString(string html, List<HtmlParseErrorEventArgs> parseErrors)
+        public static HtmlReader FromString(string html, List<HtmlParseErrorEventArgs> parseErrors, HtmlReaderOptions options = null)
         {
-            var reader = new HtmlReader(new MemoryStream(Encoding.UTF8.GetBytes(html)));
+            var reader = new HtmlReader(new MemoryStream(Encoding.UTF8.GetBytes(html)), options);
             reader.ParseError += (sender, args) => parseErrors.Add(args);
             return reader;
         }
 
-        public static HtmlReader FromStream(Stream stream, List<HtmlParseErrorEventArgs> parseErrors)
+        public static HtmlReader FromStream(Stream stream, List<HtmlParseErrorEventArgs> parseErrors, HtmlReaderOptions options = null)
         {
             stream.Seek(0, SeekOrigin.Begin);
-            var reader = new HtmlReader(stream);
+            var reader = new HtmlReader(stream, options);
             reader.ParseError += (sender, args) => parseErrors.Add(args);
             return reader;
         }

--- a/HtmlPerformanceKit.Test/RcDataTest.cs
+++ b/HtmlPerformanceKit.Test/RcDataTest.cs
@@ -156,5 +156,35 @@ namespace HtmlPerformanceKit.Test
             Assert.IsFalse(reader.Read());
             Assert.AreEqual(0, parseErrors.Count);
         }
+
+        [TestMethod]
+        public void RcDataWithCharacterReferenceWhenDecodingSkipped()
+        {
+            var options = new HtmlReaderOptions
+            {
+                SkipCharacterReferenceDecoding = true
+            };
+
+            reader = HtmlReaderFactory.FromString("<title>&amp;</title><p>", parseErrors, options);
+
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual(HtmlTokenKind.Tag, reader.TokenKind);
+            Assert.AreEqual("title", reader.Name);
+
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual(HtmlTokenKind.Text, reader.TokenKind);
+            Assert.AreEqual("&amp;", reader.Text);
+
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual(HtmlTokenKind.EndTag, reader.TokenKind);
+            Assert.AreEqual("title", reader.Name);
+
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual(HtmlTokenKind.Tag, reader.TokenKind);
+            Assert.AreEqual("p", reader.Name);
+
+            Assert.IsFalse(reader.Read());
+            Assert.AreEqual(0, parseErrors.Count);
+        }
     }
 }

--- a/HtmlPerformanceKit.Test/TagTest.cs
+++ b/HtmlPerformanceKit.Test/TagTest.cs
@@ -202,12 +202,46 @@ namespace HtmlPerformanceKit.Test
         }
 
         [TestMethod]
+        public void AttributeValueDecimalCharacterReferenceWhenDecodingSkipped()
+        {
+            var options = new HtmlReaderOptions
+            {
+                SkipCharacterReferenceDecoding = true
+            };
+
+            reader = HtmlReaderFactory.FromString("<a title=\"&#65;\">", parseErrors, options);
+
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual("&#65;", reader.GetAttribute("title"));
+
+            Assert.IsFalse(reader.Read());
+            Assert.AreEqual(0, parseErrors.Count);
+        }
+
+        [TestMethod]
         public void AttributeValueHexCharacterReference()
         {
             reader = HtmlReaderFactory.FromString("<a title=\"&#x41;\">", parseErrors);
 
             Assert.IsTrue(reader.Read());
             Assert.AreEqual("A", reader.GetAttribute("title"));
+
+            Assert.IsFalse(reader.Read());
+            Assert.AreEqual(0, parseErrors.Count);
+        }
+
+        [TestMethod]
+        public void AttributeValueHexCharacterReferenceWhenDecodingSkipped()
+        {
+            var options = new HtmlReaderOptions
+            {
+                SkipCharacterReferenceDecoding = true
+            };
+
+            reader = HtmlReaderFactory.FromString("<a title=\"&#x41;\">", parseErrors, options);
+
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual("&#x41;", reader.GetAttribute("title"));
 
             Assert.IsFalse(reader.Read());
             Assert.AreEqual(0, parseErrors.Count);
@@ -226,12 +260,46 @@ namespace HtmlPerformanceKit.Test
         }
 
         [TestMethod]
+        public void AttributeValueNamedCharacterReferenceWhenDecodingSkipped()
+        {
+            var options = new HtmlReaderOptions
+            {
+                SkipCharacterReferenceDecoding = true
+            };
+
+            reader = HtmlReaderFactory.FromString("<a title=\"&lt;\">", parseErrors, options);
+
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual("&lt;", reader.GetAttribute("title"));
+
+            Assert.IsFalse(reader.Read());
+            Assert.AreEqual(0, parseErrors.Count);
+        }
+
+        [TestMethod]
         public void AttributeValueNamedCharacterReferenceSingleQuoted()
         {
             reader = HtmlReaderFactory.FromString("<a title='&lt;'>", parseErrors);
 
             Assert.IsTrue(reader.Read());
             Assert.AreEqual("<", reader.GetAttribute("title"));
+
+            Assert.IsFalse(reader.Read());
+            Assert.AreEqual(0, parseErrors.Count);
+        }
+
+        [TestMethod]
+        public void AttributeValueNamedCharacterReferenceSingleQuotedWhenDecodingSkipped()
+        {
+            var options = new HtmlReaderOptions
+            {
+                SkipCharacterReferenceDecoding = true
+            };
+
+            reader = HtmlReaderFactory.FromString("<a title='&lt;'>", parseErrors, options);
+
+            Assert.IsTrue(reader.Read());
+            Assert.AreEqual("&lt;", reader.GetAttribute("title"));
 
             Assert.IsFalse(reader.Read());
             Assert.AreEqual(0, parseErrors.Count);

--- a/HtmlPerformanceKit/HtmlReader.cs
+++ b/HtmlPerformanceKit/HtmlReader.cs
@@ -11,6 +11,7 @@ namespace HtmlPerformanceKit
     /// </summary>
     public sealed class HtmlReader : IDisposable
     {
+        private static readonly HtmlReaderOptions DefaultOptions = new HtmlReaderOptions();
         private readonly BufferReader bufferReader;
         private readonly HtmlStateMachine stateMachine;
 
@@ -21,45 +22,68 @@ namespace HtmlPerformanceKit
         /// Initializes a new instance of the <see cref="HtmlReader" /> class.
         /// </summary>
         /// <param name="streamReader">StreamReader instance to read from.</param>
-        public HtmlReader(StreamReader streamReader)
+        /// <param name="options">The optional options.</param>
+        public HtmlReader(StreamReader streamReader, HtmlReaderOptions options = null)
         {
             if (streamReader == null)
             {
                 throw new ArgumentNullException(nameof(streamReader));
             }
 
+            if (options == null)
+            {
+                options = DefaultOptions;
+            }
+
             bufferReader = new BufferReader(streamReader);
-            stateMachine = new HtmlStateMachine(bufferReader, message => OnParseError(this, new HtmlParseErrorEventArgs(message, bufferReader.LineNumber, bufferReader.LinePosition)));
+            stateMachine = new HtmlStateMachine(bufferReader, ParseErrorFromMessage, options.SkipCharacterReferenceDecoding);
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HtmlReader" /> class.
         /// </summary>
         /// <param name="stream">Stream instance to read from.</param>
-        public HtmlReader(Stream stream)
+        /// <param name="options">The optional options.</param>
+        public HtmlReader(Stream stream, HtmlReaderOptions options = null)
         {
             if (stream == null)
             {
                 throw new ArgumentNullException(nameof(stream));
             }
 
+            if (options == null)
+            {
+                options = DefaultOptions;
+            }
+
             bufferReader = new BufferReader(new StreamReader(stream));
-            stateMachine = new HtmlStateMachine(bufferReader, message => OnParseError(this, new HtmlParseErrorEventArgs(message, bufferReader.LineNumber, bufferReader.LinePosition)));
+            stateMachine = new HtmlStateMachine(bufferReader, ParseErrorFromMessage, options.SkipCharacterReferenceDecoding);
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HtmlReader" /> class.
         /// </summary>
         /// <param name="textReader">Stream instance to read from.</param>
-        public HtmlReader(TextReader textReader)
+        /// <param name="options">The optional options.</param>
+        public HtmlReader(TextReader textReader, HtmlReaderOptions options = null)
         {
             if (textReader == null)
             {
                 throw new ArgumentNullException(nameof(textReader));
             }
 
+            if (options == null)
+            {
+                options = DefaultOptions;
+            }
+
             bufferReader = new BufferReader(textReader);
-            stateMachine = new HtmlStateMachine(bufferReader, message => OnParseError(this, new HtmlParseErrorEventArgs(message, bufferReader.LineNumber, bufferReader.LinePosition)));
+            stateMachine = new HtmlStateMachine(bufferReader, ParseErrorFromMessage, options.SkipCharacterReferenceDecoding);
+        }
+
+        private void ParseErrorFromMessage(string message)
+        {
+            OnParseError(this, new HtmlParseErrorEventArgs(message, bufferReader.LineNumber, bufferReader.LinePosition));
         }
 
         /// <summary>

--- a/HtmlPerformanceKit/HtmlReaderOptions.cs
+++ b/HtmlPerformanceKit/HtmlReaderOptions.cs
@@ -1,0 +1,13 @@
+﻿namespace HtmlPerformanceKit
+{
+    /// <summary>
+    /// Options for the HTML reader.
+    /// </summary>
+    public sealed class HtmlReaderOptions
+    {       
+        /// <summary>
+        /// True, to skip decoding of character references.
+        /// </summary>
+        public bool SkipCharacterReferenceDecoding { get; set; }
+    }
+}

--- a/HtmlPerformanceKit/StateMachine/Data/HtmlStateMachine.DataState.cs
+++ b/HtmlPerformanceKit/StateMachine/Data/HtmlStateMachine.DataState.cs
@@ -34,7 +34,7 @@ namespace HtmlPerformanceKit.StateMachine
 
                 switch (currentInputCharacter)
                 {
-                    case '&':
+                    case '&' when !skipDecodingCharacterReferences:
                         State = CharacterReferenceInDataState;
                         return;
 

--- a/HtmlPerformanceKit/StateMachine/HtmlStateMachine.cs
+++ b/HtmlPerformanceKit/StateMachine/HtmlStateMachine.cs
@@ -16,13 +16,15 @@ namespace HtmlPerformanceKit.StateMachine
         private readonly CharBuffer appropriateTagName = new CharBuffer(100);
         private readonly BufferReader bufferReader;
         private readonly Action<string> parseError;
+        private readonly bool skipDecodingCharacterReferences;
         private CurrentState returnToState;
         private char additionalAllowedCharacter;
 
-        internal HtmlStateMachine(BufferReader bufferReader, Action<string> parseError)
+        internal HtmlStateMachine(BufferReader bufferReader, Action<string> parseError, bool skipDecodingCharacterReferences)
         {
             this.bufferReader = bufferReader;
             this.parseError = parseError;
+            this.skipDecodingCharacterReferences = skipDecodingCharacterReferences;
             State = DataState;
         }
 

--- a/HtmlPerformanceKit/StateMachine/RcData/HtmlStateMachine.RcDataState.cs
+++ b/HtmlPerformanceKit/StateMachine/RcData/HtmlStateMachine.RcDataState.cs
@@ -32,7 +32,7 @@ namespace HtmlPerformanceKit.StateMachine
 
                 switch (currentInputCharacter)
                 {
-                    case '&':
+                    case '&' when !skipDecodingCharacterReferences:
                         State = CharacterReferenceInRcDataState;
                         return;
 

--- a/HtmlPerformanceKit/StateMachine/Tag/HtmlStateMachine.AttributeValueDoubleQuotedState.cs
+++ b/HtmlPerformanceKit/StateMachine/Tag/HtmlStateMachine.AttributeValueDoubleQuotedState.cs
@@ -36,7 +36,7 @@ namespace HtmlPerformanceKit.StateMachine
                         State = AfterAttributeValueQuotedState;
                         return;
 
-                    case '&':
+                    case '&' when !skipDecodingCharacterReferences:
                         State = CharacterReferenceInAttributeValueState;
                         additionalAllowedCharacter = '"';
                         returnToState = AttributeValueDoubleQuotedState;

--- a/HtmlPerformanceKit/StateMachine/Tag/HtmlStateMachine.AttributeValueSingleQuotedState.cs
+++ b/HtmlPerformanceKit/StateMachine/Tag/HtmlStateMachine.AttributeValueSingleQuotedState.cs
@@ -34,7 +34,7 @@ namespace HtmlPerformanceKit.StateMachine
                     State = AfterAttributeValueQuotedState;
                     return;
 
-                case '&':
+                case '&' when !skipDecodingCharacterReferences:
                     State = CharacterReferenceInAttributeValueState;
                     additionalAllowedCharacter = '\'';
                     returnToState = AttributeValueSingleQuotedState;

--- a/HtmlPerformanceKit/StateMachine/Tag/HtmlStateMachine.AttributeValueUnquotedState.cs
+++ b/HtmlPerformanceKit/StateMachine/Tag/HtmlStateMachine.AttributeValueUnquotedState.cs
@@ -50,7 +50,7 @@ namespace HtmlPerformanceKit.StateMachine
                     State = BeforeAttributeNameState;
                     return;
 
-                case '&':
+                case '&' when !skipDecodingCharacterReferences:
                     State = CharacterReferenceInAttributeValueState;
                     additionalAllowedCharacter = '>';
                     returnToState = AttributeValueDoubleQuotedState;


### PR DESCRIPTION
Hi,

We use your library for our mjml renderer. In some way this is just converter from mjml / html to html. Therefore entities need to be transformed to the output as is.

We could just convert the string again when writing to the output, but this is not super fast. Therefore it would be ideal if we can just skip the decoding altogether.

I added this an option to the html reader. To make future improvements easier I added a class for the options.